### PR TITLE
AMI の変更を README に反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ISUCONは3人チームで取り組むことを基準に課題が作られてい�
 
 ## 問題詳細
 * マニュアル: [ISHOCON1マニュアル](https://github.com/showwin/ISHOCON1/blob/master/doc/manual.md)
-* AMI: `ami-044fa950c36d5a250`
+* AMI: `ami-0d00b2a9a38084503`
 * インスタンスタイプ: `c5.xlarge`
 * 参考実装言語: Ruby, Go, Python, Crystal(by [@Goryudyuma](https://github.com/Goryudyuma)), Scala(by [@Goryudyuma](https://github.com/Goryudyuma))
 * 推奨実施時間: 1人で8時間


### PR DESCRIPTION
#16 で AMI が変更されていたものが README に反映されていなかったようなので変更しました。
ひとまず記述の修正に留めていますが、もしかするとここにそもそも AMI ID は記載せずに docs/manual.md のリンクに任せてもよいのかもしれません。

ご確認いただければと思います :pray: