### PR TITLE
admin/insert.rb が syntax error になるのを修正

### DIFF
--- a/admin/insert.rb
+++ b/admin/insert.rb
@@ -5,7 +5,7 @@ def config
       host: ENV['ISHOCON1_DB_HOST'] || 'localhost',
       port: ENV['ISHOCON1_DB_PORT'] && ENV['ISHOCON1_DB_PORT'].to_i,
       username: ENV['ISHOCON1_DB_USER'] || 'root',
-      password: ENV['ISHOCON1_DB_PASSWORD'] || 'ishocon1',,
+      password: ENV['ISHOCON1_DB_PASSWORD'] || 'ishocon1',
       database: ENV['ISHOCON1_DB_NAME'] || 'ishocon1'
     }
   }


### PR DESCRIPTION
手元に環境を構築するために insert.rb を実行したところsyntax error になってしまったので修正しました。

手元の
```
$ ruby --version
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin19]
```
で動作したのを確認しています。
